### PR TITLE
Refactor: Replace useContext with useUtils

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -24,7 +24,7 @@ const Dashboard = ({subscriptionPlan}: PageProps) => {
   const [currentlyDeletingFile, setCurrentlyDeletingFile] =
     useState<string | null>(null)
 
-  const utils = trpc.useContext()
+  const utils = trpc.useUtils()
 
   const { data: files, isLoading } =
     trpc.getUserFiles.useQuery()


### PR DESCRIPTION
`useUtils` is a hook that replaces `useContext`, providing cache management via `@trpc/react-query` and serving as a wrapper for `@tanstack/react-query` methods, with additional detailed documentation available.